### PR TITLE
Fix: docker build container restart failure

### DIFF
--- a/.github/workflows/build_and_push_telegram_bot.yml
+++ b/.github/workflows/build_and_push_telegram_bot.yml
@@ -58,7 +58,7 @@ jobs:
           scp -o StrictHostKeyChecking=no -i private_key "./docker/bot/docker-compose.yml" $EC2_USER@$EC2_HOST:/home/$EC2_USER/docker-compose.yml
           ssh -o StrictHostKeyChecking=no -i private_key $EC2_USER@$EC2_HOST '
             docker image prune -f &&
-            docker-compose -f /home/$EC2_USER/docker-compose.yml pull &&
-            docker-compose -f /home/$EC2_USER/docker-compose.yml down &&
-            docker-compose -f /home/$EC2_USER/docker-compose.yml up -d
+            docker-compose pull &&
+            docker-compose down &&
+            docker-compose up -d
           '


### PR DESCRIPTION
PR #1

This is a fix for failing github actions [workflow](https://github.com/vsaravind01/MarkAnn-Bot/actions/runs/9550889905/job/26324357282#step:3:23).

Updated `restart-container` job in `build-and-push-telegram_bot.yml` workflow by removing the `docker-compose` file path (-f) option.