### PR TITLE
Fix build and push telegram bot workflow by adding escape character to export `env` commands

### DIFF
--- a/.github/workflows/build_and_push_telegram_bot.yml
+++ b/.github/workflows/build_and_push_telegram_bot.yml
@@ -62,9 +62,9 @@ jobs:
             docker image prune -f &&
             docker-compose pull &&
             docker-compose down &&
-            export QDRANT_API_KEY=$QDRANT_API_KEY &&
-            export QDRANT_URL=$QDRANT_URL &&
-            export COHERE_API_KEY=$COHERE_API_KEY &&
-            export TELEGRAM_API_KEY=$TELEGRAM_API_KEY &&
+            export QDRANT_API_KEY=$QDRANT_API_KEY \
+            export QDRANT_URL=$QDRANT_URL \
+            export COHERE_API_KEY=$COHERE_API_KEY \
+            export TELEGRAM_API_KEY=$TELEGRAM_API_KEY \
             docker-compose up -d
           '


### PR DESCRIPTION
This fixes the github actions build failure [here](https://github.com/vsaravind01/MarkAnn-Bot/actions/runs/9552191969/job/26328228421#step:3:302).

Fixed restart-container run script by adding escape character at the end of export commands.