### PR TITLE
Remove export commands in restart-container script

### DIFF
--- a/.github/workflows/build_and_push_telegram_bot.yml
+++ b/.github/workflows/build_and_push_telegram_bot.yml
@@ -62,9 +62,9 @@ jobs:
             docker image prune -f &&
             docker-compose pull &&
             docker-compose down &&
-            export QDRANT_API_KEY=$QDRANT_API_KEY \
-            export QDRANT_URL=$QDRANT_URL \
-            export COHERE_API_KEY=$COHERE_API_KEY \
-            export TELEGRAM_API_KEY=$TELEGRAM_API_KEY \
+            QDRANT_API_KEY=$QDRANT_API_KEY \
+            QDRANT_URL=$QDRANT_URL \
+            COHERE_API_KEY=$COHERE_API_KEY \
+            TELEGRAM_API_KEY=$TELEGRAM_API_KEY \
             docker-compose up -d
           '


### PR DESCRIPTION
Removed export commands in restart-container script.
This should fix the issue mentioned in #4.