### PR TITLE
update escape markdown for bse link with text_link type

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -52,7 +52,7 @@ def format_message(item: dict):
             value=item["summary"]["value"],
             description=escape_markdown(item["summary"]["description"]),
             pdf_link=item["attachment"],
-            bse_link=item["url"],
+            bse_link=escape_markdown(item["url"], entity_type="text_link"),
         ),
         version=3,
     )


### PR DESCRIPTION
Updated changes:

1. Added escape_markdown for bse_link with text_link entity type